### PR TITLE
migrate door_client and update-keys to go modules

### DIFF
--- a/door_client/go.mod
+++ b/door_client/go.mod
@@ -1,0 +1,5 @@
+module github.com/realraum/door_and_sensors/door_client
+
+go 1.23.0
+
+toolchain go1.24.2

--- a/update-keys/go.mod
+++ b/update-keys/go.mod
@@ -1,0 +1,7 @@
+module github.com/realraum/door_and_sensors/update-keys
+
+go 1.23.0
+
+toolchain go1.24.2
+
+require github.com/schleibinger/sio v0.0.0-20130717070631-2cc3e40bedc0

--- a/update-keys/go.sum
+++ b/update-keys/go.sum
@@ -1,0 +1,2 @@
+github.com/schleibinger/sio v0.0.0-20130717070631-2cc3e40bedc0 h1:+zqi+jqEVTqupUr2w6E0diz3TKNBzaD01D5i4+Pvqio=
+github.com/schleibinger/sio v0.0.0-20130717070631-2cc3e40bedc0/go.mod h1:e07TMiZ8iTjzDWnGXfDSMLJ3F07CV3IvQRMvp2W1Eus=


### PR DESCRIPTION
use same go&toolchain versions as door_daemon in the repo

pls merge if ok, this change is required for the openwrt update for tuerwaechter https://github.com/realraum/noc/pull/78